### PR TITLE
Simplify install script

### DIFF
--- a/scripts/curl_install/install
+++ b/scripts/curl_install/install
@@ -37,8 +37,8 @@ curl -# $INSTALL_SCRIPT_URL > $install_script || exit
 
 chmod 775 $install_script
 
-if command -v python3 2>/dev/null; then
-   python3 $install_script < $_TTY
+if command -v python 2>/dev/null; then
+   python $install_script < $_TTY
 else
-   $install_script < $_TTY
+    python3 $install_script < $_TTY
 fi

--- a/scripts/curl_install/install.py
+++ b/scripts/curl_install/install.py
@@ -24,6 +24,9 @@ import tempfile
 import shutil
 import subprocess
 import hashlib
+
+import logging
+
 try:
     # Attempt to load python 3 module
     from urllib.request import urlopen
@@ -86,25 +89,24 @@ except CLIError as e:
 class CLIInstallError(Exception):
     pass
 
-def print_status(msg=''):
-    print('-- '+msg)
-
-def prompt_input(msg):
-    return input('\n===> '+msg)
-
-def prompt_input_with_default(msg, default):
-    if default:
-        return prompt_input("{} (leave blank to use '{}'): ".format(msg, default)) or default
-    else:
-        return prompt_input('{}: '.format(msg))
+def prompt_input(msg, default=None):
+    try:
+        if default:
+            return input("\n{} (default: {}): ".format(msg, default)) or default
+        else:
+            return input('\n{}: '.format(msg))
+    except KeyboardInterrupt:
+        raise
 
 def prompt_y_n(msg, default=None):
     if default not in [None, 'y', 'n']:
         raise ValueError("Valid values for default are 'y', 'n' or None")
+
     y = 'Y' if default == 'y' else 'y'
     n = 'N' if default == 'n' else 'n'
+
     while True:
-        ans = prompt_input('{} ({}/{}): '.format(msg, y, n))
+        ans = prompt_input('{}? ({}/{})'.format(msg, y, n))
         if ans.lower() == n.lower():
             return False
         if ans.lower() == y.lower():
@@ -113,8 +115,8 @@ def prompt_y_n(msg, default=None):
             return default == y.lower()
 
 def exec_command(command_list, cwd=None, env=None):
-    print_status('Executing: '+str(command_list))
-    subprocess.check_call(command_list, cwd=cwd, env=env)
+    logging.debug('Executing: '+str(command_list))
+    subprocess.check_output(command_list, cwd=cwd, env=env, stderr=subprocess.STDOUT)
 
 def create_tmp_dir():
     tmp_dir = tempfile.mkdtemp()
@@ -122,7 +124,7 @@ def create_tmp_dir():
 
 def create_dir(dir):
     if not os.path.isdir(dir):
-        print_status("Creating directory '{}'.".format(dir))
+        logging.debug("Creating directory '{}'.".format(dir))
         os.makedirs(dir)
 
 def is_valid_sha256sum(a_file, expected_sum):
@@ -134,16 +136,16 @@ def is_valid_sha256sum(a_file, expected_sum):
 
 def create_virtualenv(tmp_dir, install_dir):
     download_location = os.path.join(tmp_dir, VIRTUALENV_ARCHIVE)
-    print_status('Downloading virtualenv package from {}.'.format(VIRTUALENV_DOWNLOAD_URL))
+    logging.debug('Downloading virtualenv package from {}.'.format(VIRTUALENV_DOWNLOAD_URL))
     response = urlopen(VIRTUALENV_DOWNLOAD_URL)
     with open(download_location, 'wb') as f: f.write(response.read())
-    print_status("Downloaded virtualenv package to {}.".format(download_location))
+    logging.debug("Downloaded virtualenv package to {}.".format(download_location))
     if is_valid_sha256sum(download_location, VIRTUALENV_ARCHIVE_SHA256):
-        print_status("Checksum of {} OK.".format(download_location))
+        logging.debug("Checksum of {} OK.".format(download_location))
     else:
         raise CLIInstallError("The checksum of the downloaded virtualenv package does not match.")
 
-    print_status("Extracting '{}' to '{}'.".format(download_location, tmp_dir))
+    logging.debug("Extracting '{}' to '{}'.".format(download_location, tmp_dir))
     package_tar = tarfile.open(download_location)
     package_tar.extractall(path=tmp_dir)
     package_tar.close()
@@ -172,65 +174,68 @@ def create_executable(exec_dir, install_dir):
     
     cur_stat = os.stat(exec_filepath)
     os.chmod(exec_filepath, cur_stat.st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
-    print_status("The executable is available at '{}'.".format(exec_filepath))
+    logging.debug("The executable is available at '{}'.".format(exec_filepath))
+    
     return exec_filepath
 
 def get_install_dir():
     install_dir = None
     while not install_dir:
-        prompt_message = 'In what directory would you like to place the install?'
-        install_dir = prompt_input_with_default(prompt_message, DEFAULT_INSTALL_DIR)
+        prompt_message = 'Installation directory for VSTS CLI'
+        install_dir = prompt_input(prompt_message, DEFAULT_INSTALL_DIR)
         install_dir = os.path.realpath(os.path.expanduser(install_dir))
         if ' ' in install_dir:
-            print_status("The install directory '{}' cannot contain spaces.".format(install_dir))
+            logging.error("Installation directory cannot contain spaces.")
             install_dir = None
         else:
             create_dir(install_dir)
             if os.listdir(install_dir):
-                print_status("'{}' is not empty and may contain a previous installation.".format(install_dir))
-                ans_yes = prompt_y_n('Remove this directory?', 'n')
+                print("'{}' is not empty and may contain a previous installation.".format(install_dir))
+                ans_yes = prompt_y_n('Remove directory', 'n')
                 if ans_yes:
                     shutil.rmtree(install_dir)
-                    print_status("Deleted '{}'.".format(install_dir))
+                    logging.debug("Deleted '{}'.".format(install_dir))
                     create_dir(install_dir)
                 else:
                     # User opted to not delete the directory so ask for install directory again
                     install_dir = None
-    print_status("We will install at '{}'.".format(install_dir))
+
     return install_dir
 
 def get_exec_dir():
     exec_dir = None
     while not exec_dir:
-        prompt_message = "In what directory would you like to place the '{}' executable?".format(EXECUTABLE_NAME)
-        exec_dir = prompt_input_with_default(prompt_message, DEFAULT_EXEC_DIR)
+        prompt_message = "Directory for VSTS CLI executable ({})".format(EXECUTABLE_NAME)
+        exec_dir = prompt_input(prompt_message, DEFAULT_EXEC_DIR)
         exec_dir = os.path.realpath(os.path.expanduser(exec_dir))
         if ' ' in exec_dir:
-            print_status("The executable directory '{}' cannot contain spaces.".format(exec_dir))
+            logging.error("Executable directory cannot contain spaces.")
             exec_dir = None
     create_dir(exec_dir)
-    print_status("The executable will be in '{}'.".format(exec_dir))
+
     return exec_dir
 
 def _backup_rc(rc_file):
     try:
         shutil.copyfile(rc_file, rc_file+'.backup')
-        print_status("Backed up '{}' to '{}'".format(rc_file, rc_file+'.backup'))
+        logging.debug("Backed up '{}' to '{}'".format(rc_file, rc_file+'.backup'))
     except (OSError, IOError):
         pass
 
 def _get_default_rc_file():
     bashrc_exists = os.path.isfile(USER_BASH_RC)
     bash_profile_exists = os.path.isfile(USER_BASH_PROFILE)
+    
     if not bashrc_exists and bash_profile_exists:
         return USER_BASH_PROFILE
     if bashrc_exists and bash_profile_exists and platform.system().lower() == 'darwin':
         return USER_BASH_PROFILE
+    
     return USER_BASH_RC if bashrc_exists else None
 
 def _default_rc_file_creation_step():
     rcfile = USER_BASH_PROFILE if platform.system().lower() == 'darwin' else USER_BASH_RC
-    ans_yes = prompt_y_n('Could not automatically find a suitable file to use. Create {} now?'.format(rcfile), default='y')
+    ans_yes = prompt_y_n('Could not find suitable bashrc file to use. Create {}'.format(rcfile), default='y')
     if ans_yes:
         open(rcfile, 'a').close()
         return rcfile
@@ -254,19 +259,20 @@ def _modify_rc(rc_file_path, line_to_add):
 def create_tab_completion_file(filename):
     with open(filename, 'w') as completion_file:
         completion_file.write(PYTHON_ARGCOMPLETE_CODE)
-    print_status("Created tab completion file at '{}'".format(filename))
+    logging.debug("Created tab completion file at '{}'".format(filename))
 
 def get_rc_file_path():
     rc_file = None
     default_rc_file = _get_default_rc_file()
     if not default_rc_file:
         rc_file = _default_rc_file_creation_step()
-    rc_file = rc_file or prompt_input_with_default('Enter a path to an rc file to update', default_rc_file)
+    rc_file = rc_file or prompt_input('Path to bashrc file to update', default_rc_file)
     if rc_file:
         rc_file_path = os.path.realpath(os.path.expanduser(rc_file))
         if os.path.isfile(rc_file_path):
             return rc_file_path
-        print_status("The file '{}' could not be found.".format(rc_file_path))
+        else:
+            logging.debug("The file '{}' could not be found.".format(rc_file_path))
     return None
 
 def warn_other_clis_on_path(exec_dir, exec_filepath):
@@ -278,13 +284,12 @@ def warn_other_clis_on_path(exec_dir, exec_filepath):
             if p != exec_dir and os.path.isfile(p_to_cli):
                 conflicting_paths.append(p_to_cli)
     if conflicting_paths:
-        print_status()
-        print_status("** WARNING: Other '{}' executables are on your $PATH. **".format(EXECUTABLE_NAME))
-        print_status("Conflicting paths: {}".format(', '.join(conflicting_paths)))
-        print_status("You can run this installation of the CLI with '{}'.".format(exec_filepath))
+        print("WARNING: Other '{}' executables exist on your $PATH".format(EXECUTABLE_NAME))
+        print("  {}".format(', '.join(conflicting_paths)))
+        print("To run this installation use: {}".format(exec_filepath))
 
 def handle_path_and_tab_completion(completion_file_path, exec_filepath, exec_dir):
-    ans_yes = prompt_y_n('Modify profile to update your $PATH and enable shell/tab completion now?', 'y')
+    ans_yes = prompt_y_n('Add VSTS CLI to your $PATH and enable tab completion', 'y')
     if ans_yes:
         rc_file_path = get_rc_file_path()
         if not rc_file_path:
@@ -294,45 +299,44 @@ def handle_path_and_tab_completion(completion_file_path, exec_filepath, exec_dir
         _modify_rc(rc_file_path, line_to_add)
         line_to_add = "source '{}'".format(completion_file_path)
         _modify_rc(rc_file_path, line_to_add)
-        print_status('Tab completion set up complete.')
-        print_status("If tab completion is not activated, verify that '{}' is sourced by your shell.".format(rc_file_path))
-        warn_other_clis_on_path(exec_dir, exec_filepath)
-        print_status()
-        print_status('** Run `exec -l $SHELL` to restart your shell. **')
-        print_status()
+        logging.debug('Tab completion set up complete.')
+        logging.debug("If tab completion is not activated, verify that '{}' is sourced by your shell.".format(rc_file_path))
+        logging.debug('** Run `exec -l $SHELL` to restart your shell. **')
     else:
-        print_status("If you change your mind, add 'source {}' to your rc file and restart your shell to enable tab completion.".format(completion_file_path))
-        print_status("You can run the CLI with '{}'.".format(exec_filepath))
+        logging.debug("If you change your mind, add 'source {}' to your rc file and restart your shell to enable tab completion.".format(completion_file_path))
+        logging.debug("You can run the CLI with '{}'.".format(exec_filepath))
 
 def verify_python_version():
-    print_status('Verifying Python version.')
+    logging.debug('Verifying Python version.')
     v = sys.version_info
     if v < (2, 7):
         raise CLIInstallError('The CLI does not support Python versions less than 2.7.')
     if 'conda' in sys.version:
         raise CLIInstallError("This script does not support the Python Anaconda environment. "
                               "Create an Anaconda virtual environment and install with 'pip'")
-    print_status('Python version {}.{}.{} okay.'.format(v.major, v.minor, v.micro))
+    logging.debug('Python version {}.{}.{} okay.'.format(v.major, v.minor, v.micro))
 
 def _native_dependencies_for_dist(verify_cmd_args, install_cmd_args, dep_list):
     try:
-        print_status("Executing: '{} {}'".format(' '.join(verify_cmd_args), ' '.join(dep_list)))
+        logging.debug("Executing: '{} {}'".format(' '.join(verify_cmd_args), ' '.join(dep_list)))
         subprocess.check_output(verify_cmd_args + dep_list, stderr=subprocess.STDOUT)
-        print_status('Native dependencies okay.')
+        logging.debug('Native dependencies okay.')
     except subprocess.CalledProcessError:
-        err_msg = 'One or more of the following native dependencies are not currently installed and may be required.\n'
-        err_msg += '"{}"'.format(' '.join(install_cmd_args + dep_list))
-        print_status(err_msg)
-        ans_yes = prompt_y_n('Missing native dependencies. Attempt to continue anyway?', 'n')
+        print('')
+        print('Missed required dependencies:')
+        print(' {}'.format(' '.join(dep_list)))
+        ans_yes = prompt_y_n('Continue anyway', 'n')
         if not ans_yes:
-            raise CLIInstallError('Please install the native dependencies and try again.')
+            raise CLIInstallError('Install required dependencies and re-run the install.')
+        else:
+            print('')
 
 def verify_native_dependencies():
     distname, version, _ = platform.linux_distribution()
     if not distname:
         # There's no distribution name so can't determine native dependencies required / or they may not be needed like on OS X
         return
-    print_status('Verifying native dependencies.')
+    logging.debug('Verifying native dependencies.')
     is_python3 = sys.version_info[0] == 3
     distname = distname.lower().strip()
     verify_cmd_args = None
@@ -360,7 +364,7 @@ def verify_native_dependencies():
     if verify_cmd_args and install_cmd_args and dep_list:
         _native_dependencies_for_dist(verify_cmd_args, install_cmd_args, dep_list)
     else:
-        print_status("Unable to verify native dependencies. dist={}, version={}. Continuing...".format(distname, version))
+        logging.debug("Unable to verify native dependencies. dist={}, version={}. Continuing...".format(distname, version))
 
 def verify_install_dir_exec_path_conflict(install_dir, exec_path):
     if install_dir == exec_path:
@@ -372,23 +376,23 @@ def verify_python_executable(install_dir):
     
     executing_python = sys.executable
     installed_python = os.path.join(install_dir, 'bin/python')
-    print_status("Current executable {}".format(executing_python))
-    print_status("Installed executable {}".format(installed_python))
+    logging.debug("Current executable {}".format(executing_python))
+    logging.debug("Installed executable {}".format(installed_python))
     
     if 'Python.framework' in sys.prefix:
-        print_status("Is Python.framework")
+        logging.debug("Is Python.framework")
         if os.path.exists(installed_python):
-            print_status("Installed Python executable exists")
+            logging.debug("Installed Python executable exists")
             try:       
                 # backup the python executable that was placed in the install directory (vsts-cli/bin)
                 shutil.copyfile(installed_python, installed_python + '.backup')
-                print_status("Created backup of installed Python executable")
+                logging.debug("Created backup of installed Python executable")
 
                 # replace with the currently executing python executable
                 shutil.copyfile(executing_python, installed_python)
-                print_status("Replaced installed Python executable")
+                logging.debug("Replaced installed Python executable")
             except (OSError, IOError):
-                print_status("Failed to replace installed Python executable:".format(str(e)))
+                logging.debug("Failed to replace installed Python executable")
                 pass
 
 
@@ -404,21 +408,31 @@ def verify_keyring_access(install_dir, tmp_dir):
     try:
         exec_command(cmd, cwd=os.path.dirname(installed_python))
     except subprocess.CalledProcessError as e:
-        #print_status("Return code: {}".format(str(e)))
+        #logging.debug("Return code: {}".format(str(e)))
         pip = os.path.join(install_dir, 'bin/pip')
         cmd = [ pip, "install", "keyrings.alt" ]
         exec_command(cmd, cwd=os.path.dirname(pip))
 
 
 def main():
+    print("")
+    print("Microsoft Visual Studio Team Services CLI (0.1.0) Install")
+
     verify_python_version()
     verify_native_dependencies()
 
     tmp_dir = create_tmp_dir()
     install_dir = get_install_dir()
     exec_dir = get_exec_dir()
+        
+    logging.debug("The executable will be in '{}'.".format(exec_dir))
+
     exec_path = os.path.join(exec_dir, EXECUTABLE_NAME)
     verify_install_dir_exec_path_conflict(install_dir, exec_path)
+
+    print("")
+    print("Installing. This may take a few minutes...")
+
     create_virtualenv(tmp_dir, install_dir)
     verify_python_executable(install_dir)
     
@@ -431,19 +445,24 @@ def main():
     create_tab_completion_file(completion_file_path)
     try:
        handle_path_and_tab_completion(completion_file_path, exec_filepath, exec_dir)
+       warn_other_clis_on_path(exec_dir, exec_filepath)
     except Exception as e:
-        print_status("Unable to set up tab completion. ERROR: {}".format(str(e)))
+        print("Unable to configure tab completion. ERROR: {}".format(str(e)))
     
     shutil.rmtree(tmp_dir)
     
-    print_status("Installation successful.")
-    print_status("Run the CLI with {} --help".format(exec_filepath))
+    print("")
+    print("Installation successful!")
+    print("Note: you may need to restart your shell (exec -l $SHELL)")
+    print("")
+    print("To run VSTS CLI: {} --help".format(EXECUTABLE_NAME))
+    print("")
 
 if __name__ == '__main__':
     try:
         main()
     except CLIInstallError as cie:
-        print('ERROR: '+str(cie), file=sys.stderr)
+        print('ERROR: {}\n'.format(str(cie)), file=sys.stderr)
         sys.exit(1)
     except KeyboardInterrupt:
         print('\n\nExiting...')

--- a/src/common_modules/vsts-cli-common/vsts/cli/common/_credentials.py
+++ b/src/common_modules/vsts-cli-common/vsts/cli/common/_credentials.py
@@ -11,7 +11,11 @@ from knack.util import CLIError
 from vsts._file_cache import get_cache
 from .uri import uri_parse
 
-
+#
+# IMPORTANT: This function is called by the install script (scripts/curl_install/install.py)
+#            to verify that credentials can be accessed. Be careful when changing this method
+#            so it does not impact install.
+#
 def get_credential(team_instance):
     key = _get_service_name(team_instance)
     logging.debug('Getting credential: %s', key)


### PR DESCRIPTION
1. Avoid creating the executable script if one already got created (because of pip install vsts-cli)
2. Simplify the wording of prompts
3. Be more clear about what we did and how to run the CLI after install

This partially addresses issue #77, but there is still additional logic needed to handle the case where pip install places "vsts" in the /usr/local/bin (or other existing $PATH directory). When this happens, we don't need to try adding the install directory to the $PATH or creating an executable.