### PR TITLE
Improve error message when --project is not specified but required by telling the user how to configure default (similar to --instance error message)

### DIFF
--- a/src/common_modules/vsts-cli-common/vsts/cli/common/services.py
+++ b/src/common_modules/vsts-cli-common/vsts/cli/common/services.py
@@ -126,7 +126,7 @@ def _raise_team_team_instance_arg_error():
 
 
 def _raise_team_project_arg_error():
-    raise CLIError('--project must be specified. The value should be the ID or name of a team project.' +
+    raise CLIError('--project must be specified. The value should be the ID or name of a team project. ' +
                    'You can set a default value by running: vsts configure --defaults project=<ProjectName>.')
 
 

--- a/src/common_modules/vsts-cli-common/vsts/cli/common/services.py
+++ b/src/common_modules/vsts-cli-common/vsts/cli/common/services.py
@@ -126,7 +126,8 @@ def _raise_team_team_instance_arg_error():
 
 
 def _raise_team_project_arg_error():
-    raise CLIError('--project must be specified. The value should be the ID or name of a team project.')
+    raise CLIError('--project must be specified. The value should be the ID or name of a team project.' +
+                   'You can set a default value by running: vsts configure --defaults project=<ProjectName>.')
 
 
 def resolve_instance_project_and_repo(detect, team_instance, project=None, project_required=True, repo=None):


### PR DESCRIPTION
Improve error message when --project is not specified but required by telling the user how to configure the default (similar to the error about --instance)