### PR TITLE
Require that required arguments to upack commands are not empty

### DIFF
--- a/src/command_modules/vsts-cli-package/vsts/cli/package/arguments.py
+++ b/src/command_modules/vsts-cli-package/vsts/cli/package/arguments.py
@@ -4,11 +4,18 @@
 # --------------------------------------------------------------------------------------------
 
 from knack.arguments import ArgumentsContext
+from argparse import ArgumentTypeError
 
 def load_package_arguments(cli_command_loader):
     with ArgumentsContext(cli_command_loader, 'package upack') as ac:
         ac.argument('team_instance', options_list=('--instance'))
-        ac.argument('feed', options_list=('--feed'))
-        ac.argument('package_name', options_list=('--package-name'))
-        ac.argument('package_version', options_list=('--package-version'))
-        ac.argument('description', options_list=('--description'))
+        ac.argument('feed', type=nonempty_str)
+        ac.argument('name', type=nonempty_str)
+        ac.argument('version', type=nonempty_str)
+        ac.argument('path', type=nonempty_str)
+        ac.argument('description')
+
+def nonempty_str(s):
+    if not s.strip():
+        raise ArgumentTypeError("value must not be empty")
+    return s


### PR DESCRIPTION
Arguments to the upack commands are passed straight through to ArtifactTool. This results in a confusing user experience when arguments are empty, as error messages will reference the ArtifactTool parameter names, not the vsts-cli parameter names.

This PR sets the 'type' of the arguments (really just an arbitrary callable to transform the argument) to a function that enforces that the value is non empty.
I also removed the options_list values because they were simply restating the default.
I also changed package_name and package_version to name and version because those were wrong.

This produces a nice error message like 
```
usage: vsts package upack publish [-h] [--verbose] [--debug]
                                  [--output {json,jsonc,table,tsv}]
                                  [--query JMESPATH] --instance TEAM_INSTANCE
                                  --feed FEED --name NAME --version VERSION
                                  --path PATH [--description DESCRIPTION]
vsts package upack publish: error: argument --version: value must not be empty
```

cc: @zarenner 
