### PR TITLE
Fix docgen

### DIFF
--- a/scripts/docgen/conf.py
+++ b/scripts/docgen/conf.py
@@ -62,7 +62,7 @@ master_doc = 'ind'
 
 # General information about the project.
 project = 'vsts-cli'
-copyright = '2017, msft'
+copyright = '2018, msft'
 author = 'msft'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/scripts/docgen/doc_source_map.json
+++ b/scripts/docgen/doc_source_map.json
@@ -2,5 +2,7 @@
     "build": "src/command_modules/vsts-cli-build/vsts/cli/build/_help.py",
     "code": "src/command_modules/vsts-cli-code/vsts/cli/code/_help.py",    
     "team": "src/command_modules/vsts-cli-team/vsts/cli/team/_help.py",
-    "work": "src/command_modules/vsts-cli-work/vsts/cli/work/_help.py"
+    "work": "src/command_modules/vsts-cli-work/vsts/cli/work/_help.py",
+    "admin": "src/command_modules/vsts-cli-admin/vsts/cli/admin/_help.py",
+    "package": "src/command_modules/vsts-cli-package/vsts/cli/package/_help.py"
 }

--- a/scripts/docgen/extensions/vsts.py
+++ b/scripts/docgen/extensions/vsts.py
@@ -8,6 +8,7 @@ from __future__ import print_function
 import argparse
 import json
 import os
+from os.path import expanduser
 import sys
 
 from docutils import nodes
@@ -20,59 +21,34 @@ from vsts.cli.vsts_commands_loader import VstsCommandsLoader
 
 from knack import CLI
 from knack import help as _help
+from knack.help import GroupHelpFile, CommandHelpFile, ArgumentGroupRegistry 
+
+USER_HOME = expanduser('~')
 
 class VstsHelpGenDirective(Directive):
     def make_rst(self):
         INDENT = '   '
         DOUBLEINDENT = INDENT * 2
-        parser_keys = []
-        parser_values = []
-        sub_parser_keys = []
-        sub_parser_values = []
-
         # similar to what the Application object provides for in "az"
         cli_name = "vsts"
-        vstscli = CLI(cli_name=cli_name,
+        vsts_cli = CLI(cli_name=cli_name,
                 config_dir=os.path.join('~', '.{}'.format(cli_name)),
                 config_env_var_prefix=cli_name,
                 commands_loader_cls=VstsCommandsLoader,
                 help_cls=VstsCLIHelp)
 
-        loader = vstscli.commands_loader_cls()
-        loader.__init__(vstscli)
-        loader.load_command_table([])
-        for command in loader.command_table:
-            loader.load_arguments(command)
+        help_files = get_help_files(vsts_cli)
 
-        vstsclihelp = vstscli.help_cls(cli_ctx=vstscli)
-
-        global_parser = vstscli.parser_cls.create_global_parser(cli_ctx=vstscli)
-        parser = vstscli.parser_cls(cli_ctx=vstscli, prog=vstscli.name, parents=[global_parser])
-        parser.load_command_table(loader.command_table)
-
-        _store_parsers(parser, parser_keys, parser_values, sub_parser_keys, sub_parser_values)
-        for cmd, parser in zip(parser_keys, parser_values):
-            if cmd not in sub_parser_keys:
-                sub_parser_keys.append(cmd)
-                sub_parser_values.append(parser)
         doc_source_map = _load_doc_source_map()
 
-        help_files = []
-        for cmd, parser in zip(sub_parser_keys, sub_parser_values):
-            try:
-                help_file = _help.GroupHelpFile(cmd, parser) if _is_group(parser) else _help.CommandHelpFile(cmd, parser)
-                help_file.load(parser)
-                help_files.append(help_file)
-            except Exception as ex:
-                print("Skipped '{}' due to '{}'".format(cmd, ex))
-        help_files = sorted(help_files, key=lambda x: x.command)
-
         for help_file in help_files:
-            is_command = isinstance(help_file, _help.CommandHelpFile)
-            yield '.. cli{}:: {}'.format('command' if is_command else 'group', help_file.command if help_file.command else 'vsts') #it is top level group vsts if command is empty
+            is_command = isinstance(help_file, CommandHelpFile)
+            yield '.. cli{}:: {}'.format('command' if is_command else 'group', help_file.command if help_file.command else 'vsts') #it is top level group az if command is empty
             yield ''
             yield '{}:summary: {}'.format(INDENT, help_file.short_summary)
             yield '{}:description: {}'.format(INDENT, help_file.long_summary)
+            if help_file.deprecate_info:
+                yield '{}:deprecated: {}'.format(INDENT, help_file.deprecate_info._get_message(help_file.deprecate_info))
             if not is_command:
                 top_group_name = help_file.command.split()[0] if help_file.command else 'vsts' 
                 yield '{}:docsource: {}'.format(INDENT, doc_source_map[top_group_name] if top_group_name in doc_source_map else '')
@@ -83,35 +59,46 @@ class VstsHelpGenDirective(Directive):
             yield ''
 
             if is_command and help_file.parameters:
-               group_registry = _help.ArgumentGroupRegistry(
+               group_registry = ArgumentGroupRegistry(
                   [p.group_name for p in help_file.parameters if p.group_name]) 
 
                for arg in sorted(help_file.parameters,
                                 key=lambda p: group_registry.get_group_priority(p.group_name)
                                 + str(not p.required) + p.name):
-                  yield '{}.. cliarg:: {}'.format(INDENT, arg.name)
-                  yield ''
-                  yield '{}:required: {}'.format(DOUBLEINDENT, arg.required)
-                  short_summary = arg.short_summary or ''
-                  possible_values_index = short_summary.find(' Possible values include')
-                  short_summary = short_summary[0:possible_values_index
-                                                if possible_values_index >= 0 else len(short_summary)]
-                  short_summary = short_summary.strip()
-                  yield '{}:summary: {}'.format(DOUBLEINDENT, short_summary)
-                  yield '{}:description: {}'.format(DOUBLEINDENT, arg.long_summary)
-                  if arg.choices:
-                     yield '{}:values: {}'.format(DOUBLEINDENT, ', '.join(sorted([str(x) for x in arg.choices])))
-                  if arg.default and arg.default != argparse.SUPPRESS:
-                     yield '{}:default: {}'.format(DOUBLEINDENT, arg.default)
-                  if arg.value_sources:
-                     yield '{}:source: {}'.format(DOUBLEINDENT, ', '.join(arg.value_sources))
-                  yield ''
+                    yield '{}.. cliarg:: {}'.format(INDENT, arg.name)
+                    yield ''
+                    yield '{}:required: {}'.format(DOUBLEINDENT, arg.required)
+                    if arg.deprecate_info:
+                        yield '{}:deprecated: {}'.format(DOUBLEINDENT, arg.deprecate_info._get_message(arg.deprecate_info))
+                    short_summary = arg.short_summary or ''
+                    possible_values_index = short_summary.find(' Possible values include')
+                    short_summary = short_summary[0:possible_values_index
+                                                    if possible_values_index >= 0 else len(short_summary)]
+                    short_summary = short_summary.strip()
+                    yield '{}:summary: {}'.format(DOUBLEINDENT, short_summary)
+                    yield '{}:description: {}'.format(DOUBLEINDENT, arg.long_summary)
+                    if arg.choices:
+                        yield '{}:values: {}'.format(DOUBLEINDENT, ', '.join(sorted([str(x) for x in arg.choices])))
+                    if arg.default and arg.default != argparse.SUPPRESS:
+                        try:
+                            if arg.default.startswith(USER_HOME):
+                                arg.default = arg.default.replace(USER_HOME, '~').replace('\\', '/')
+                        except Exception:
+                            pass
+                        try:
+                            arg.default = arg.default.replace("\\", "\\\\")
+                        except Exception:
+                            pass
+                        yield '{}:default: {}'.format(DOUBLEINDENT, arg.default)
+                    if arg.value_sources:
+                        yield '{}:source: {}'.format(DOUBLEINDENT, ', '.join(arg.value_sources))
+                    yield ''
             yield ''
             if len(help_file.examples) > 0:
                for e in help_file.examples:
                   yield '{}.. cliexample:: {}'.format(INDENT, e.name)
                   yield ''
-                  yield DOUBLEINDENT + e.text
+                  yield DOUBLEINDENT + e.text.replace("\\", "\\\\")
                   yield ''
 
     def run(self):
@@ -123,6 +110,37 @@ class VstsHelpGenDirective(Directive):
 
         nested_parse_with_titles(self.state, result, node)
         return node.children
+
+
+def get_help_files(cli_ctx):
+    cli_ctx.invocation = cli_ctx.invocation_cls(cli_ctx=cli_ctx, commands_loader_cls=cli_ctx.commands_loader_cls, parser_cls=cli_ctx.parser_cls, help_cls=cli_ctx.help_cls)
+    cli_ctx.invocation.commands_loader.load_command_table([])
+    cmd_table = cli_ctx.invocation.commands_loader.command_table
+    for command in cmd_table:
+        cli_ctx.invocation.commands_loader.load_arguments(command)
+    cli_ctx.invocation.parser.load_command_table(cli_ctx.invocation.commands_loader)
+
+    parser_keys = []
+    parser_values = []
+    sub_parser_keys = []
+    sub_parser_values = []
+    _store_parsers(cli_ctx.invocation.parser, parser_keys, parser_values, sub_parser_keys, sub_parser_values)
+    for cmd, parser in zip(parser_keys, parser_values):
+        if cmd not in sub_parser_keys:
+            sub_parser_keys.append(cmd)
+            sub_parser_values.append(parser)
+
+    help_ctx = cli_ctx.help_cls(cli_ctx=cli_ctx)
+    help_files = []
+    for cmd, parser in zip(sub_parser_keys, sub_parser_values):
+        try:
+            help_file = GroupHelpFile(help_ctx, cmd, parser) if _is_group(parser) else help_ctx.command_help_cls(help_ctx, cmd, parser)
+            help_file.load(parser)
+            help_files.append(help_file)
+        except Exception as ex:
+            print("Skipped '{}' due to '{}'".format(cmd, ex))
+    help_files = sorted(help_files, key=lambda x: x.command)
+    return help_files
 
 def setup(app):
     app.add_directive('vsts', VstsHelpGenDirective)


### PR DESCRIPTION
Mitch Denny got the following error when trying to run the doc gen tool:

```
Exception occurred:
  File "C:\Code\vsts-cli\scripts\env\lib\site-packages\knack\parser.py", line 88, in load_command_table
    cmd_tbl = command_loader.command_table
AttributeError: 'dict' object has no attribute 'command_table'
```

Something changed in Knack which caused this to no longer work. This PR syncs key parts from the latest AZ CLI script into the VSTS CLI script.