### PR TITLE
Now that logger.exception correctly emits to CLI, don't do it for CLIError

### DIFF
--- a/src/common_modules/vsts-cli-common/vsts/cli/common/_credentials.py
+++ b/src/common_modules/vsts-cli-common/vsts/cli/common/_credentials.py
@@ -55,7 +55,6 @@ def clear_credential(team_instance):
     try:
         keyring.delete_password(key, _USERNAME)
     except keyring.errors.PasswordDeleteError as ex:
-        logger.exception(ex)
         raise CLIError('The credential was not found')
 
 

--- a/src/common_modules/vsts-cli-common/vsts/cli/common/exception_handling.py
+++ b/src/common_modules/vsts-cli-common/vsts/cli/common/exception_handling.py
@@ -12,9 +12,9 @@ from .services import raise_authentication_error
 logger = get_logger(__name__)
 
 def handle_command_exception(exception):
-    logger.exception(exception)
     if isinstance(exception, CLIError):
         raise exception
     if isinstance(exception, VstsAuthenticationError):
         raise_authentication_error(exception)
+    logger.exception(exception)
     raise CLIError(exception)


### PR DESCRIPTION
Without this PR, user errors are being emitted twice - first as a full callstack due to this logger.exception, and then later in Knack as an error.