### PR TITLE
Universal Packages: Fix logging output when ArtifactTool output unparsable, by always emitting stderr as string not byte array

### DIFF
--- a/src/common_modules/vsts-cli-package-common/vsts/cli/package/common/external_tool.py
+++ b/src/common_modules/vsts-cli-package-common/vsts/cli/package/common/external_tool.py
@@ -46,7 +46,7 @@ class ExternalToolInvoker:
         if self._proc.returncode != 0 and not self._terminating:
             stderr = self._proc.stderr.read().strip()
             if stderr != "":
-                stderr = "\n" + stderr
+                stderr = "\n{}".format(stderr)
             raise CLIError("Process {proc} with PID {pid} exited with return code {code}{err}".format(proc=self._args, pid=self._proc.pid, code=self._proc.returncode, err=stderr))
         return self._proc
 
@@ -68,7 +68,7 @@ class ProgressReportingExternalToolInvoker(ExternalToolInvoker):
             self.start(command_args, env)
             try:
                 for line in iter(self._proc.stderr.readline, b''):
-                    stderr_handler(line, self._update_progress)
+                    stderr_handler(str(line), self._update_progress)
                 return self.wait()
             except IOError as ex:
                 if not self._terminating:


### PR DESCRIPTION
#### Actual
```
Universal Packages is currently in preview.
Failed to parse structured output from Universal Packages tooling (ArtifactTool)
Exception: the JSON object must be str, not 'bytes'
Log line: b'Failed to load x\xcf\x8d\x01, error: libunwind.so.8: cannot open shared object file: No such file or directory\n'
```

#### Expected
```
Universal Packages is currently in preview.
Failed to parse structured output from Universal Packages tooling (ArtifactTool)
Exception: Expecting value: line 1 column 1 (char 0)
Log line: b'Failed to load x/\x97\x01, error: libunwind.so.8: cannot open shared object file: No such file or directory\n'