### PR TITLE
Adding work items batch query limit as 200

### DIFF
--- a/src/common_modules/vsts-cli-work-common/vsts/cli/work/common/work_item.py
+++ b/src/common_modules/vsts-cli-work-common/vsts/cli/work/common/work_item.py
@@ -278,6 +278,7 @@ def query_work_items(wiql=None, query_id=None, path=None, team_instance=None, pr
                     break
         remaining_url_length -= fields_length_in_url
         max_work_items = 1000
+        work_items_batch_size = 200
         current_batch = []
         work_items = []
         work_item_url_length = 0
@@ -290,7 +291,7 @@ def query_work_items(wiql=None, query_id=None, path=None, team_instance=None, pr
             work_item_url_length += len(str(work_item_ref.id))
             current_batch.append(work_item_ref.id)
 
-            if remaining_url_length - work_item_url_length <= 0:
+            if remaining_url_length - work_item_url_length <= 0 or len(current_batch) == work_items_batch_size :
                 # url is near max length, go ahead and send first request for details.
                 # url can go over by an id length because we have a safety buffer
                 current_batched_items = client.get_work_items(ids=current_batch,


### PR DESCRIPTION
Currently 'get_work_items' API takes upto 200 work item IDs at a time. 
Hence limiting the batch size to 200. (Total upto 1000 work items would be displayed)
