### PR TITLE
Removing keyrings.alt and fixing urls for rebranding change

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,8 +55,6 @@ RUN pip install vsts --upgrade --no-cache-dir --extra-index-url https://vstscli.
    /vsts-cli/src/command_modules/vsts-cli-release \
    /vsts-cli/src/vsts-cli
 
-# Install alternate keyring backend
-RUN pip install --no-cache-dir keyrings.alt
 
 # Setup tab completion
 RUN cat /vsts-cli/scripts/vsts.completion > ~/.bashrc

--- a/src/common_modules/vsts-cli-common/vsts/cli/common/_credentials.py
+++ b/src/common_modules/vsts-cli-common/vsts/cli/common/_credentials.py
@@ -3,13 +3,19 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-import keyring
 
-from knack.util import CLIError
+import os
+import sys
+from knack.config import CLIConfig
+from knack.util import CLIError, ensure_dir
+from six.moves import configparser
 from .uri import uri_parse
 
 from knack.log import get_logger
 logger = get_logger(__name__)
+
+from .config import GLOBAL_CONFIG_DIR
+_PAT_FILE = os.path.join(GLOBAL_CONFIG_DIR, 'personalAccessTokens')
 
 #
 # IMPORTANT: This function is called by the install script (scripts/curl_install/install.py)
@@ -27,16 +33,27 @@ def _get_credential(team_instance):
     key = _get_service_name(team_instance)
     logger.debug('Getting credential: %s', key)
     try:
+        import keyring
         return keyring.get_password(key, _USERNAME)
     except RuntimeError as ex:
-        logger.debug(ex, exc_info=True)
-        raise CLIError(ex)
+        #fetch credentials from file if keyring is missing
+        if sys.platform.startswith(_LINUX_PLATFORM):
+            ensure_dir(GLOBAL_CONFIG_DIR)
+            logger.debug('Keyring package not found. Fetching credentials from the file: %s', _PAT_FILE)
+            creds_list = _get_credentials_list()
+            try:
+                return creds_list.get(key, _USERNAME)
+            except (configparser.NoOptionError, configparser.NoSectionError):
+                return None
+        else:
+            logger.debug(ex, exc_info=True)
+            raise CLIError(ex)
 
 
 def set_credential(team_instance, token):
     try:
         key = _get_service_name(team_instance)
-
+        import keyring
         # check for and delete existing credential
         old_token = keyring.get_password(key, _USERNAME)
         if old_token is not None:
@@ -45,17 +62,39 @@ def set_credential(team_instance, token):
         logger.debug('Setting credential: %s', key)
         keyring.set_password(key, _USERNAME, token)
     except RuntimeError as ex:
-        logger.debug(ex, exc_info=True)
-        raise CLIError(ex)
+        #store credentials in azuredevops config directory if keyring is missing
+        if sys.platform.startswith(_LINUX_PLATFORM):
+            logger.debug('Keyring package not found. Hence, storing credentials in the file: %s', _PAT_FILE)  
+            creds_list = _get_credentials_list()
+            if key not in creds_list.sections():
+                creds_list.add_section(key)
+                logger.debug('Added new entry to PAT file : %s ',key)
+            creds_list.set(key, _USERNAME, token)
+            _commit_change(creds_list)
+        else:
+            logger.debug(ex, exc_info=True)
+            raise CLIError(ex)
 
 
 def clear_credential(team_instance):
     key = _get_service_name(team_instance)
     logger.debug('Clearing credential: %s', key)
     try:
+        import keyring
         keyring.delete_password(key, _USERNAME)
     except keyring.errors.PasswordDeleteError as ex:
         raise CLIError('The credential was not found')
+    except RuntimeError as ex :        
+        if sys.platform.startswith(_LINUX_PLATFORM):
+            logger.debug('Keyring package not found. Checking file for credentials: %s', _PAT_FILE)
+            creds_list = _get_credentials_list()
+            if key not in creds_list.sections():
+                    raise CLIError('The credential was not found')
+            creds_list.remove_section(key)
+            _commit_change(creds_list)
+        else:
+            logger.debug(ex, exc_info=True)
+            raise CLIError(ex)
 
 
 def _get_service_name(team_instance):
@@ -67,8 +106,31 @@ def _get_service_name(team_instance):
 
 def normalize_url_for_key(url):
     components = uri_parse(url)
-    return components.scheme.lower() + '://' + components.netloc.lower()
+    normalized_url = components.scheme.lower() + '://' + components.netloc.lower() + components.path.lower()
+    normalized_url = normalized_url.rstrip('/')
+    return normalized_url
+
+
+def _get_config_parser():
+    if sys.version_info.major == 3:
+        return configparser.ConfigParser(interpolation=None)
+    return configparser.ConfigParser()
+
+
+def _get_credentials_list():
+    try:
+        credential_list = _get_config_parser()
+        credential_list.read(_PAT_FILE)
+        return credential_list
+    except Exception: 
+        return _get_config_parser()
+
+
+def _commit_change(credential_list):
+    with open(_PAT_FILE, 'w+') as creds_file:
+            credential_list.write(creds_file)
 
 
 # a value is required for the python config file that gets generated on some operating systems.
 _USERNAME = 'Personal Access Token'
+_LINUX_PLATFORM = 'linux'

--- a/src/common_modules/vsts-cli-common/vsts/cli/tests/test_credentials.py
+++ b/src/common_modules/vsts-cli-common/vsts/cli/tests/test_credentials.py
@@ -7,7 +7,8 @@ import unittest
 import uuid
 from ..common._credentials import (get_credential,
                                    set_credential,
-                                   clear_credential)
+                                   clear_credential,
+                                   normalize_url_for_key)
 
 
 class TestCredentialsMethods(unittest.TestCase):
@@ -79,6 +80,16 @@ class TestCredentialsMethods(unittest.TestCase):
             if original_token is not None:
                 # restore original token
                 set_credential(None, original_token)
+
+     def test_normalize_url_for_key(self):
+        #new url
+        devops_organization = 'https://dev.azure.com/AzureDevOpsCliOrg'
+        normalized_url = normalize_url_for_key(devops_organization)
+        self.assertEqual(normalized_url , 'https://dev.azure.com/azuredevopscliorg')
+        #old url
+        devops_organization = 'https://mseng.visualstudio.com/'
+        normalized_url = normalize_url_for_key(devops_organization)
+        self.assertEqual(normalized_url , 'https://mseng.visualstudio.com')
 
 
 if __name__ == '__main__':

--- a/src/common_modules/vsts-cli-common/vsts/cli/tests/test_credentials.py
+++ b/src/common_modules/vsts-cli-common/vsts/cli/tests/test_credentials.py
@@ -81,7 +81,7 @@ class TestCredentialsMethods(unittest.TestCase):
                 # restore original token
                 set_credential(None, original_token)
 
-     def test_normalize_url_for_key(self):
+    def test_normalize_url_for_key(self):
         #new url
         devops_organization = 'https://dev.azure.com/AzureDevOpsCliOrg'
         normalized_url = normalize_url_for_key(devops_organization)


### PR DESCRIPTION
Since, keyrings.alt package is  less secure, removing dependency on keyrings.alt package and storing credentials in file when keyring is missing.
This is done to support some linux distributions where keyring is not available.
A personalAccessTokens file will be created at path $HOME/.vsts/cli , which will be used to store the PAT tokens

Also fixing service url to include organization name for new azure devops URLs