### PR TITLE
Fixing open browser argument for devops project context

### DIFF
--- a/azure-devops/azext_devops/dev/team/arguments.py
+++ b/azure-devops/azext_devops/dev/team/arguments.py
@@ -32,6 +32,7 @@ def load_team_arguments(self, _):
         context.argument('defaults', options_list=('--defaults', '-d'), nargs='*')
     with self.argument_context('devops project') as context:
         context.argument('devops_organization', options_list=('--organization', '--org'))
+        context.argument('open_browser', options_list='--open')
         context.argument('process', options_list=('--process', '-p'))
         context.argument('source_control', options_list=('--source-control', '-s'),
                     **enum_choice_list(_SOURCE_CONTROL_VALUES))


### PR DESCRIPTION
Changing argument name from default '--open-browser' to '--open'