### PR TITLE
Send Linux distro name and version when resolving ArtifactTool to download

### DIFF
--- a/src/common_modules/vsts-cli-package-common/setup.py
+++ b/src/common_modules/vsts-cli-package-common/setup.py
@@ -17,6 +17,7 @@ VERSION = '0.1.4'
 
 REQUIRES = [
     'colorama>=0.3.9',
+    'distro==1.3.0',
     'humanfriendly==4.7',
     'knack==0.4.1',
     'python-dateutil==2.7.3',

--- a/src/common_modules/vsts-cli-package-common/vsts/cli/package/common/artifacttool_updater.py
+++ b/src/common_modules/vsts-cli-package-common/vsts/cli/package/common/artifacttool_updater.py
@@ -13,6 +13,7 @@ import tempfile
 import uuid
 import zipfile
 
+import distro
 import humanfriendly
 import requests
 
@@ -72,7 +73,10 @@ class ArtifactToolUpdater:
         connection = get_vss_connection(team_instance)
         client = connection.get_client('vsts.cli.package.common.client_tool.client_tool_client.ClientToolClient')
         logger.debug("Looking up current version of ArtifactTool...")
-        release = client.get_clienttool_release("ArtifactTool", os_name=platform.system(), arch=platform.machine(), version=override_version)
+        # Distro returns empty strings on Windows currently, so don't even send
+        distro_name = distro.id() or None
+        distro_version = distro.version() or None
+        release = client.get_clienttool_release("ArtifactTool", os_name=platform.system(), arch=platform.machine(), distro_name=distro_name, distro_version=distro_version, version=override_version)
         return (release.uri, self._compute_id(release)) if release is not None else None
 
     def _update_artifacttool(self, uri, release_id):

--- a/src/common_modules/vsts-cli-package-common/vsts/cli/package/common/client_tool/client_tool_client.py
+++ b/src/common_modules/vsts-cli-package-common/vsts/cli/package/common/client_tool/client_tool_client.py
@@ -17,7 +17,7 @@ class ClientToolClient(VssClient):
 
     resource_area_identifier = '3fda18ba-dff2-42e6-8d10-c521b23b85fc'
 
-    def get_clienttool_release(self, tool_name, os_name=None, arch=None, version=None):
+    def get_clienttool_release(self, tool_name, os_name=None, arch=None, distro_name=None, distro_version=None, version=None):
         route_values = {}
         if tool_name is not None:
             route_values['toolName'] = self._serialize.url('tool_name', tool_name, 'str')
@@ -26,6 +26,10 @@ class ClientToolClient(VssClient):
             query_parameters['osName'] = self._serialize.query('os_name', os_name, 'str')
         if arch is not None:
             query_parameters['arch'] = self._serialize.query('arch', arch, 'str')
+        if distro_name is not None:
+            query_parameters['distroName'] = self._serialize.query('distro_name', distro_name, 'str')
+        if distro_version is not None:
+            query_parameters['distroVersion'] = self._serialize.query('distro_version', distro_version, 'str')                        
         if version is not None:
             query_parameters['version'] = self._serialize.query('version', version, 'str')
         response = self._send(http_method='GET',


### PR DESCRIPTION
Part of fix for #217

Basically we need to send the distro name up to blobstore service, so that it can send down the alpine-x64 variant of ArtifactTool rather than the linux-x64 variant.

Tested on Alpine, makes request:
`vsts.vss_client : GET https://vsblob.dev.azure.com/mseng/_apis/clienttools/ArtifactTool/release?distroVersion=3.8.1&distroName=alpine&arch=x86_64&osName=Linux`