### PR TITLE
Ignore UTF-8 decoding errors when reading output from ArtifactTool. S…

### DIFF
--- a/src/common_modules/vsts-cli-package-common/vsts/cli/package/common/external_tool.py
+++ b/src/common_modules/vsts-cli-package-common/vsts/cli/package/common/external_tool.py
@@ -44,7 +44,7 @@ class ExternalToolInvoker:
         # Ensure process completed, and emit error if returncode is non-zero (including any remaining stderr)
         self._proc.wait()
         if self._proc.returncode != 0 and not self._terminating:
-            stderr = self._proc.stderr.read().decode('utf-8').strip()
+            stderr = self._proc.stderr.read().decode('utf-8', 'ignore').strip()
             if stderr != "":
                 stderr = "\n{}".format(stderr)
             raise CLIError("Process {proc} with PID {pid} exited with return code {code}{err}".format(proc=self._args, pid=self._proc.pid, code=self._proc.returncode, err=stderr))
@@ -68,7 +68,7 @@ class ProgressReportingExternalToolInvoker(ExternalToolInvoker):
             self.start(command_args, env)
             try:
                 for bline in iter(self._proc.stderr.readline, b''):
-                    line = bline.decode('utf-8').strip()
+                    line = bline.decode('utf-8', 'ignore').strip()
                     stderr_handler(line, self._update_progress)
                 return self.wait()
             except IOError as ex:


### PR DESCRIPTION
…ome errors due to missing dependencies for .NET CLR contain non-UTF-8 characters, which makes the CLI hide these errors behind a decoding one.