### PR TITLE
Telemetry related fixes

### DIFF
--- a/azure-devops/azext_devops/dev/common/services.py
+++ b/azure-devops/azext_devops/dev/common/services.py
@@ -27,6 +27,7 @@ logger = get_logger(__name__)
 
 
 def get_vss_connection(devops_organization):
+    devops_organization = devops_organization.lower()
     if devops_organization not in _vss_connection:
         credentials = _get_credentials(devops_organization)
         try:

--- a/azure-devops/azext_devops/dev/common/telemetry.py
+++ b/azure-devops/azext_devops/dev/common/telemetry.py
@@ -88,7 +88,7 @@ def _send_tracking_ci_event(devops_organization=None, ci_client=None):
         logger.debug(ex, exc_info=True)
         return False
 
-
+# azure cli uses this to get shell type from os environment
 def _get_shell_type():
     import os
     if 'ZSH_VERSION' in os.environ:

--- a/azure-devops/azext_devops/dev/common/telemetry.py
+++ b/azure-devops/azext_devops/dev/common/telemetry.py
@@ -88,6 +88,7 @@ def _send_tracking_ci_event(devops_organization=None, ci_client=None):
         logger.debug(ex, exc_info=True)
         return False
 
+
 # azure cli uses this to get shell type from os environment
 def _get_shell_type():
     import os

--- a/azure-devops/azext_devops/dev/common/telemetry.py
+++ b/azure-devops/azext_devops/dev/common/telemetry.py
@@ -29,7 +29,7 @@ def set_tracking_data(argv):
         if argv:
             vsts_tracking_data.feature = argv[0]
         else:
-            vsts_tracking_data.feature = 'Command'
+            vsts_tracking_data.feature = None
         if len(argv) > 1:
             command = []
             args = []
@@ -46,6 +46,7 @@ def set_tracking_data(argv):
             else:
                 vsts_tracking_data.properties['Command'] = ''
             vsts_tracking_data.properties['Args'] = args
+            vsts_tracking_data.properties['ShellType'] = _get_shell_type()
 
     except BaseException as ex:
         logger.debug(ex, exc_info=True)
@@ -63,7 +64,8 @@ def _is_telemetry_enabled():
 
 
 def _try_send_tracking_ci_event_async(devops_organization=None):
-    if vsts_tracking_data is not None and vsts_tracking_data.area is not None:
+    if (vsts_tracking_data is not None and vsts_tracking_data.area is not None and
+            vsts_tracking_data.feature is not None):
         logger.debug("Logging telemetry to azure devops server.")
         try:
             thread = threading.Thread(target=_send_tracking_ci_event, args=[devops_organization])
@@ -85,6 +87,32 @@ def _send_tracking_ci_event(devops_organization=None, ci_client=None):
     except BaseException as ex:
         logger.debug(ex, exc_info=True)
         return False
+
+
+def _get_shell_type():
+    import os
+    if 'ZSH_VERSION' in os.environ:
+        return 'zsh'
+    if 'BASH_VERSION' in os.environ:
+        return 'bash'
+    if 'KSH_VERSION' in os.environ or 'FCEDIT' in os.environ:
+        return 'ksh'
+    if 'WINDIR' in os.environ:
+        return 'cmd'
+    return _remove_cmd_chars(_remove_symbols(os.environ.get('SHELL')))
+
+
+def _remove_cmd_chars(s):
+    if isinstance(s, str):
+        return s.replace("'", '_').replace('"', '_').replace('\r\n', ' ').replace('\n', ' ')
+    return s
+
+
+def _remove_symbols(s):
+    if isinstance(s, str):
+        for c in '$%^&|':
+            s = s.replace(c, '_')
+    return s
 
 
 vsts_tracking_data = CustomerIntelligenceEvent()

--- a/azure-devops/azext_devops/test/boards/test_workitem.py
+++ b/azure-devops/azext_devops/test/boards/test_workitem.py
@@ -20,7 +20,7 @@ from azext_devops.dev.common.services import clear_connection_cache
 
 class TestWorkItemMethods(unittest.TestCase):
 
-    _TEST_DEVOPS_ORGANIZATION = 'https://AzureDevOpsCliTest.visualstudio.com'
+    _TEST_DEVOPS_ORGANIZATION = 'https://azuredevopsclitest.visualstudio.com'
     _TEST_PAT_TOKEN = 'lwghjbj67fghokrgxsytghg75nk2ssguljk7a78qpcg2ttygviyt'
 
     def setUp(self):

--- a/azure-devops/azext_devops/test/common/test_services.py
+++ b/azure-devops/azext_devops/test/common/test_services.py
@@ -1,0 +1,32 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import unittest
+
+try:
+    # Attempt to load mock (works on Python 3.3 and above)
+    from unittest.mock import patch
+except ImportError:
+    # Attempt to load mock (works on Python version below 3.3)
+    from mock import patch
+
+from azext_devops.dev.common.telemetry import (set_tracking_data, 
+    try_send_telemetry_data, vsts_tracking_data)
+
+from azext_devops.dev.common.services import get_vss_connection
+
+class TestServicesMethods(unittest.TestCase):
+    
+    _TEST_DEVOPS_ORGANIZATION = 'https://dev.azure.com/AzureDevOpsCliTest'
+   
+    def test_get_vss_connection_cache_works(self):
+        with patch('azext_devops.dev.common.services._get_credentials') as mock_get_credentials:  
+            with patch('azext_devops.dev.common.telemetry.try_send_telemetry_data') as mock_telemetry_send:
+                get_vss_connection(self._TEST_DEVOPS_ORGANIZATION)
+                get_vss_connection(self._TEST_DEVOPS_ORGANIZATION.lower())
+                #assert
+                mock_telemetry_send.assert_called_once_with(self._TEST_DEVOPS_ORGANIZATION.lower())
+                mock_get_credentials.assert_called_once()
+

--- a/azure-devops/azext_devops/test/common/test_services.py
+++ b/azure-devops/azext_devops/test/common/test_services.py
@@ -15,11 +15,15 @@ except ImportError:
 from azext_devops.dev.common.telemetry import (set_tracking_data, 
     try_send_telemetry_data, vsts_tracking_data)
 
-from azext_devops.dev.common.services import get_vss_connection
+from azext_devops.dev.common.services import get_vss_connection, clear_connection_cache
 
-class TestServicesMethods(unittest.TestCase):
-    
+
+class TestServicesMethods(unittest.TestCase):    
     _TEST_DEVOPS_ORGANIZATION = 'https://dev.azure.com/AzureDevOpsCliTest'
+    _TEST_DEVOPS_ORGANIZATION2 = 'https://dev.azure.com/MyOrganization'
+
+    def setUp(self):
+        clear_connection_cache()
    
     def test_get_vss_connection_cache_works(self):
         with patch('azext_devops.dev.common.services._get_credentials') as mock_get_credentials:  
@@ -30,3 +34,15 @@ class TestServicesMethods(unittest.TestCase):
                 mock_telemetry_send.assert_called_once_with(self._TEST_DEVOPS_ORGANIZATION.lower())
                 mock_get_credentials.assert_called_once()
 
+    def test_get_vss_connection_cache_works_mulitple_organization(self):
+        with patch('azext_devops.dev.common.services._get_credentials') as mock_get_credentials:  
+            with patch('azext_devops.dev.common.telemetry.try_send_telemetry_data') as mock_telemetry_send:
+                get_vss_connection(self._TEST_DEVOPS_ORGANIZATION)
+                get_vss_connection(self._TEST_DEVOPS_ORGANIZATION2)
+                #assert
+                self.assertEqual(2, mock_get_credentials.call_count)
+                self.assertEqual(2, mock_telemetry_send.call_count)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/azure-devops/azext_devops/test/common/test_telemetry.py
+++ b/azure-devops/azext_devops/test/common/test_telemetry.py
@@ -48,5 +48,5 @@ class TestTelemetryMethods(unittest.TestCase):
     def test_set_tracking_data_should_set_data_correctly_with_none(self):
         set_tracking_data(None)
         assert vsts_tracking_data.area == 'AzureDevopsCli'
-        assert vsts_tracking_data.feature == 'Command'
+        assert vsts_tracking_data.feature == None
         assert vsts_tracking_data.properties == {} 

--- a/azure-devops/azext_devops/test/repos/test_pull_request.py
+++ b/azure-devops/azext_devops/test/repos/test_pull_request.py
@@ -39,7 +39,7 @@ from azext_devops.dev.common.services import clear_connection_cache
 
 class TestPullRequestMethods(unittest.TestCase):
 
-    _TEST_DEVOPS_ORGANIZATION = 'https://AzureDevOpsCliTest.visualstudio.com'
+    _TEST_DEVOPS_ORGANIZATION = 'https://azuredevopsclitest.visualstudio.com'
     _TEST_PAT_TOKEN = 'lwghjbj67fghokrgxsytghg75nk2ssguljk7a78qpcg2ttygviyt'
     _TEST_PROJECT_NAME = 'sample_project'
     _TEST_REPOSITORY_NAME = 'sample_repository'


### PR DESCRIPTION
1. Add support for logging shell type in CI (code from azure cli)
1. Fix issue in vss_Connection cache - case mismatch was resulting in cache miss
1. Telemetry is getting logged in UTs (needs to be fixed - get_vss_connection call should not be made in UTs), this PR handles not to log the telemetry
1. Added tests