### PR TITLE
Fixing error message for login with invalid token

### DIFF
--- a/azure-devops/azext_devops/dev/team/credentials.py
+++ b/azure-devops/azext_devops/dev/team/credentials.py
@@ -31,7 +31,9 @@ def credential_set(devops_organization=None):
         connection = _get_vss_connection(devops_organization, credentials)
         location_client = connection.get_client('vsts.location.v4_1.location_client.LocationClient')
         try:
-            location_client.get_connection_data()
+            connection_data = location_client.get_connection_data()
+            if connection_data.authenticated_user.id == _ANONYMOUS_USER_ID:
+                raise CLIError("Failed to authenticate using the supplied token.")
         except Exception as ex2:
             logger.debug(ex2, exc_info=True)
             raise CLIError("Failed to authenticate using the supplied token.")
@@ -90,3 +92,6 @@ def _check_and_clear_default_organization(devops_organization):
             logger.debug("Resetting default organization.")
         else:
             logger.debug("Default org not reset. Different organization is set as default.")
+
+
+_ANONYMOUS_USER_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'

--- a/azure-devops/azext_devops/dev/team/credentials.py
+++ b/azure-devops/azext_devops/dev/team/credentials.py
@@ -32,11 +32,14 @@ def credential_set(devops_organization=None):
         location_client = connection.get_client('vsts.location.v4_1.location_client.LocationClient')
         try:
             connection_data = location_client.get_connection_data()
-            if connection_data.authenticated_user.id == _ANONYMOUS_USER_ID:
-                raise CLIError("Failed to authenticate using the supplied token.")
         except Exception as ex2:
             logger.debug(ex2, exc_info=True)
             raise CLIError("Failed to authenticate using the supplied token.")
+        else:
+            # An organization with public project enabled will not throw any exception for invalid token.
+            # Hence, handle anonymous user case here.
+            if connection_data.authenticated_user.id == _ANONYMOUS_USER_ID:
+                raise CLIError("Failed to authenticate using the supplied token.")
     set_credential(devops_organization=devops_organization, token=token)
     _check_and_set_default_organization(devops_organization)
 

--- a/azure-devops/azext_devops/dev/team/credentials.py
+++ b/azure-devops/azext_devops/dev/team/credentials.py
@@ -35,11 +35,10 @@ def credential_set(devops_organization=None):
         except Exception as ex2:
             logger.debug(ex2, exc_info=True)
             raise CLIError("Failed to authenticate using the supplied token.")
-        else:
-            # An organization with public project enabled will not throw any exception for invalid token.
-            # Hence, handle anonymous user case here.
-            if connection_data.authenticated_user.id == _ANONYMOUS_USER_ID:
-                raise CLIError("Failed to authenticate using the supplied token.")
+        # An organization with public project enabled will not throw any exception for invalid token.
+        # Hence, handle anonymous user case here.
+        if connection_data.authenticated_user.id == _ANONYMOUS_USER_ID:
+            raise CLIError("Failed to authenticate using the supplied token.")
     set_credential(devops_organization=devops_organization, token=token)
     _check_and_set_default_organization(devops_organization)
 


### PR DESCRIPTION
An organization with public projects enabled will not throw any exception for invalid token. Hence, handling anonymous user case here in login command.