### PR TITLE
use run pip from azure cli core instead of having our own implementat…

### DIFF
--- a/azure-devops/azext_devops/dev/common/credential_store.py
+++ b/azure-devops/azext_devops/dev/common/credential_store.py
@@ -24,8 +24,8 @@ class CredentialStore:
         except ImportError:
             install_keyring()
             self._initialize_keyring()
+            import keyring
 
-        import keyring
         try:
             # check for and delete existing credential
             old_token = keyring.get_password(key, self._USERNAME)
@@ -73,8 +73,8 @@ class CredentialStore:
         except ImportError:
             install_keyring()
             self._initialize_keyring()
+            import keyring
 
-        import keyring
         try:
             keyring.delete_password(key, self._USERNAME)
         except keyring.errors.PasswordDeleteError:

--- a/azure-devops/azext_devops/dev/common/pip_helper.py
+++ b/azure-devops/azext_devops/dev/common/pip_helper.py
@@ -3,9 +3,9 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-import pip
-
 from knack.log import get_logger
+
+from azure.cli.core.extension.operations import _run_pip
 
 logger = get_logger(__name__)
 
@@ -16,7 +16,5 @@ def install_keyring():
 
 def _install_package(package_name):
     logger.debug('installing %s', package_name)
-    if hasattr(pip, 'main'):
-        pip.main(['install', package_name])  # pylint: disable=no-member
-    else:
-        pip._internal.main(['install', package_name])  # pylint: disable=protected-access
+    pip_args = ['install', package_name]
+    _run_pip(pip_args)  # pylint: disable=protected-access

--- a/azure-devops/azext_devops/test/common/test_pip_helper.py
+++ b/azure-devops/azext_devops/test/common/test_pip_helper.py
@@ -1,0 +1,18 @@
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+import unittest
+
+class TestPipHelperMethods(unittest.TestCase):
+
+    def test_run_pip_is_present_in_cli_core(self):
+        try:
+            from azure.cli.core.extension.operations import _run_pip
+        except ImportError:
+            self.fail('dependency on cli core is broken, pip helper will need fix')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
use run pip from azure cli core instead of having our own implementation.

also added UT to make sure dependecy is checked in cli core so that we can react (as this is not a public method)